### PR TITLE
Add nuke radius preview option

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -1,4 +1,5 @@
 import { EventBus, GameEvent } from "../core/EventBus";
+import { Cell } from "../core/game/Game";
 import { UnitView } from "../core/game/GameView";
 import { UserSettings } from "../core/game/UserSettings";
 import { ReplaySpeedMultiplier } from "./utilities/ReplaySpeedMultiplier";
@@ -76,6 +77,12 @@ export class ShowEmojiMenuEvent implements GameEvent {
     public readonly y: number,
   ) {}
 }
+
+export class BuildMenuOpenedEvent implements GameEvent {
+  constructor(public readonly tile: Cell) {}
+}
+
+export class BuildMenuClosedEvent implements GameEvent {}
 
 export class DoBoatAttackEvent implements GameEvent {}
 

--- a/src/client/graphics/GameRenderer.ts
+++ b/src/client/graphics/GameRenderer.ts
@@ -18,6 +18,7 @@ import { Leaderboard } from "./layers/Leaderboard";
 import { MainRadialMenu } from "./layers/MainRadialMenu";
 import { MultiTabModal } from "./layers/MultiTabModal";
 import { NameLayer } from "./layers/NameLayer";
+import { NukePreviewLayer } from "./layers/NukePreviewLayer";
 import { OptionsMenu } from "./layers/OptionsMenu";
 import { PlayerInfoOverlay } from "./layers/PlayerInfoOverlay";
 import { PlayerPanel } from "./layers/PlayerPanel";
@@ -210,6 +211,7 @@ export function createRenderer(
     new TerritoryLayer(game, eventBus, transformHandler),
     structureLayer,
     new UnitLayer(game, eventBus, transformHandler),
+    new NukePreviewLayer(game, eventBus, transformHandler),
     new FxLayer(game),
     new UILayer(game, eventBus, transformHandler),
     new NameLayer(game, transformHandler),

--- a/src/client/graphics/layers/BuildMenu.ts
+++ b/src/client/graphics/layers/BuildMenu.ts
@@ -15,6 +15,7 @@ import { EventBus } from "../../../core/EventBus";
 import { Cell, Gold, PlayerActions, UnitType } from "../../../core/game/Game";
 import { TileRef } from "../../../core/game/GameMap";
 import { GameView } from "../../../core/game/GameView";
+import { BuildMenuClosedEvent, BuildMenuOpenedEvent } from "../../InputHandler";
 import { BuildUnitIntentEvent } from "../../Transport";
 import { renderNumber } from "../../Utils";
 import { Layer } from "./Layer";
@@ -406,12 +407,18 @@ export class BuildMenu extends LitElement implements Layer {
   hideMenu() {
     this._hidden = true;
     this.requestUpdate();
+    this.eventBus.emit(new BuildMenuClosedEvent());
   }
 
   showMenu(clickedTile: TileRef) {
     this.clickedTile = clickedTile;
     this._hidden = false;
     this.refresh();
+    this.eventBus.emit(
+      new BuildMenuOpenedEvent(
+        new Cell(this.game.x(clickedTile), this.game.y(clickedTile)),
+      ),
+    );
   }
 
   private refresh() {

--- a/src/client/graphics/layers/NukePreviewLayer.ts
+++ b/src/client/graphics/layers/NukePreviewLayer.ts
@@ -1,0 +1,92 @@
+import { EventBus } from "../../../core/EventBus";
+import { Cell, UnitType } from "../../../core/game/Game";
+import { GameView } from "../../../core/game/GameView";
+import { UserSettings } from "../../../core/game/UserSettings";
+import {
+  BuildMenuClosedEvent,
+  BuildMenuOpenedEvent,
+  MouseMoveEvent,
+} from "../../InputHandler";
+import { TransformHandler } from "../TransformHandler";
+import { Layer } from "./Layer";
+
+export class NukePreviewLayer implements Layer {
+  private canvas: HTMLCanvasElement;
+  private context: CanvasRenderingContext2D;
+  private visible = false;
+  private lastCell: Cell | null = null;
+  private radius: number;
+  private userSettings = new UserSettings();
+
+  constructor(
+    private game: GameView,
+    private eventBus: EventBus,
+    private transformHandler: TransformHandler,
+  ) {
+    this.radius = this.game.config().nukeMagnitudes(UnitType.AtomBomb).outer;
+  }
+
+  shouldTransform(): boolean {
+    return true;
+  }
+
+  init() {
+    this.redraw();
+    this.eventBus.on(MouseMoveEvent, (e) => this.onMouseMove(e));
+    this.eventBus.on(BuildMenuOpenedEvent, () => {
+      this.visible = true;
+    });
+    this.eventBus.on(BuildMenuClosedEvent, () => {
+      this.visible = false;
+      this.clear();
+    });
+  }
+
+  redraw() {
+    this.canvas = document.createElement("canvas");
+    const ctx = this.canvas.getContext("2d");
+    if (ctx === null) throw new Error("2d context not supported");
+    this.context = ctx;
+    this.canvas.width = this.game.width();
+    this.canvas.height = this.game.height();
+  }
+
+  private clear() {
+    this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+  }
+
+  private draw() {
+    if (!this.lastCell) return;
+    this.clear();
+    const ref = this.game.ref(this.lastCell.x, this.lastCell.y);
+    const x = this.game.x(ref);
+    const y = this.game.y(ref);
+    this.context.beginPath();
+    this.context.arc(x, y, this.radius, 0, Math.PI * 2);
+    this.context.strokeStyle = "rgba(255,255,255,0.7)";
+    this.context.lineWidth = 1;
+    this.context.stroke();
+  }
+
+  private onMouseMove(e: MouseMoveEvent) {
+    if (!this.visible || !this.userSettings.nukePreview()) return;
+    const cell = this.transformHandler.screenToWorldCoordinates(e.x, e.y);
+    if (!this.game.isValidCoord(cell.x, cell.y)) {
+      this.clear();
+      return;
+    }
+    this.lastCell = cell;
+    this.draw();
+  }
+
+  renderLayer(context: CanvasRenderingContext2D) {
+    if (!this.visible || !this.userSettings.nukePreview()) return;
+    context.drawImage(
+      this.canvas,
+      -this.game.width() / 2,
+      -this.game.height() / 2,
+      this.game.width(),
+      this.game.height(),
+    );
+  }
+}

--- a/src/client/graphics/layers/OptionsMenu.ts
+++ b/src/client/graphics/layers/OptionsMenu.ts
@@ -111,6 +111,11 @@ export class OptionsMenu extends LitElement implements Layer {
     this.eventBus.emit(new RefreshGraphicsEvent());
   }
 
+  private onToggleNukePreviewButtonClick() {
+    this.userSettings.toggleNukePreview();
+    this.requestUpdate();
+  }
+
   private onToggleRandomNameModeButtonClick() {
     this.userSettings.toggleRandomName();
   }
@@ -211,6 +216,11 @@ export class OptionsMenu extends LitElement implements Layer {
             onClick: this.onToggleDarkModeButtonClick,
             title: "Dark Mode",
             children: "🌙: " + (this.userSettings.darkMode() ? "On" : "Off"),
+          })}
+          ${button({
+            onClick: this.onToggleNukePreviewButtonClick,
+            title: "Nuke Preview",
+            children: "☢️: " + (this.userSettings.nukePreview() ? "On" : "Off"),
           })}
           ${button({
             onClick: this.onToggleRandomNameModeButtonClick,

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -29,6 +29,10 @@ export class UserSettings {
     return this.get("settings.darkMode", false);
   }
 
+  nukePreview() {
+    return this.get("settings.nukePreview", false);
+  }
+
   leftClickOpensMenu() {
     return this.get("settings.leftClickOpensMenu", false);
   }
@@ -57,6 +61,10 @@ export class UserSettings {
 
   toggleFxLayer() {
     this.set("settings.specialEffects", !this.fxLayer());
+  }
+
+  toggleNukePreview() {
+    this.set("settings.nukePreview", !this.nukePreview());
   }
 
   toggleDarkMode() {


### PR DESCRIPTION
## Summary
- add `nukePreview` setting with toggle
- expose build menu open/close events
- add NukePreviewLayer to display bomb radius
- allow toggling the preview from Options menu

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684d93e1fd80832388e47d2e54401837