### PR TITLE
Add premium Chrome extension for purple theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ npm run start:server-dev
 - `/src/core` - Shared game logic
 - `/src/server` - Backend game server
 - `/resources` - Static assets (images, maps, etc.)
+- `/premium-extension` - Chrome extension that applies a purple theme for premium users
 
 ## 📝 License
 

--- a/premium-extension/README.md
+++ b/premium-extension/README.md
@@ -1,0 +1,16 @@
+# OpenFront Premium Chrome Extension
+
+This extension changes the game's primary theme color to purple for premium users.
+
+## Installing
+
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this `premium-extension` folder.
+4. Set the `isPremium` flag in extension storage to `true` using the extension options or via the developer console:
+   ```js
+   chrome.storage.sync.set({ isPremium: true });
+   ```
+5. Reload the OpenFront page and the theme color will switch to purple.
+
+Only users with premium accounts should enable the extension.

--- a/premium-extension/background.js
+++ b/premium-extension/background.js
@@ -1,0 +1,9 @@
+/* global chrome */
+chrome.runtime.onInstalled.addListener(() => {
+  // Set default value. Users with premium accounts should have this set to true.
+  chrome.storage.sync.get("isPremium", (result) => {
+    if (result.isPremium === undefined) {
+      chrome.storage.sync.set({ isPremium: false });
+    }
+  });
+});

--- a/premium-extension/content.js
+++ b/premium-extension/content.js
@@ -1,0 +1,10 @@
+/* global chrome */
+chrome.storage.sync.get("isPremium", ({ isPremium }) => {
+  if (isPremium) {
+    document.documentElement.style.setProperty("--primaryColor", "#7e22ce");
+    document.documentElement.style.setProperty(
+      "--primaryColorHover",
+      "#6b21a8",
+    );
+  }
+});

--- a/premium-extension/manifest.json
+++ b/premium-extension/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "OpenFront Premium Theme",
+  "version": "1.0",
+  "description": "Change the game theme to purple for premium users.",
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ],
+  "action": {
+    "default_title": "OpenFront Premium Theme"
+  }
+}


### PR DESCRIPTION
## Summary
- add a `premium-extension` folder with manifest and scripts
- change theme color to purple if `isPremium` flag is enabled
- document the extension and add its directory to project structure in README

## Testing
- `npm run lint`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_b_684d9a7bb2e483239829e762bd759ee8